### PR TITLE
Skip errors when parsing keys and fingerprints

### DIFF
--- a/key_table_gen.py
+++ b/key_table_gen.py
@@ -1,12 +1,4 @@
 #!/usr/bin/python
-# Written by Dave Boxall, Stiliyana Simeonova
-# Version 1.3
-# Jan 8th 2019
-# PGP Key Directory maintenance script
-#
-# CHANGELOG
-# 1.3 - take into account revokation key folder to generate list of revoked keys as well
-#
 
 import os, sys
 
@@ -39,11 +31,14 @@ inputfiles = ['pk.txt']
 with open("pkb.txt","w") as outfile:
   for fname in inputfiles:
     with open(fname) as infile:
-      for line in infile:
+      for index, line in enumerate(infile):
         x = line.split(" ")
-        q  = x[2]
-        r = q[:1]
-        outfile.write('<H2><BOLD>'+r+'</BOLD></H2>\n'+line+'\n') 
+        if (len(x) > 2):
+          q  = x[2]
+          r = q[:1]
+          outfile.write('<H2><BOLD>'+r+'</BOLD></H2>\n'+line+'\n')
+        else:
+          print('Something when wrong with line %s: %s' % (index, line))
 outfile.close() 
 infile.close()
 
@@ -54,12 +49,15 @@ inputfiles = ['fp.txt']
 with open("fpb.txt","w") as outfile:
   for fname in inputfiles:
     with open(fname) as infile:
-      for line in infile:
+      for index, line in enumerate(infile):
         x = line.split(" ")
-        q  = x[2]
-        r = q[:1]
-        outfile.write('<H2><BOLD>'+r+'</BOLD></H2>\n'+line+'\n') 
-outfile.close() 
+        if (len(x) > 2):
+          q  = x[2]
+          r = q[:1]
+          outfile.write('<H2><BOLD>'+r+'</BOLD></H2>\n'+line+'\n')
+        else:
+          print('Something when wrong with line %s: %s' % (index, line))
+outfile.close()
 infile.close()
 
 os.system("cat fpb.txt | awk '!x[$0]++'>fpc.txt")

--- a/key_table_gen.py
+++ b/key_table_gen.py
@@ -1,12 +1,16 @@
 #!/usr/bin/python
-# Written by Dave Boxall
-# Version 1.2
-# Feb 19th 2016
+# Written by Dave Boxall, Stiliyana Simeonova
+# Version 1.3
+# Jan 8th 2019
 # PGP Key Directory maintenance script
+#
+# CHANGELOG
+# 1.3 - take into account revokation key folder to generate list of revoked keys as well
+#
 
 import os, sys
 
-for i in sorted(os.listdir('home/ec2-user/PublicKeys')):
+for i in sorted(os.listdir('/home/ec2-user/PublicKeys')):
     if i.endswith(".pub.txt"):
         fo = open("pk.txt", "a")
         b = i.replace("."," ")
@@ -15,7 +19,7 @@ for i in sorted(os.listdir('home/ec2-user/PublicKeys')):
         fo.write('<p><a href="PublicKeys/'+i+' "class="kinfo">'+q+'</a></p>\n')
         fo.close()
 
-for i in sorted(os.listdir('home/ec2-user/Fingerprints')):
+for i in sorted(os.listdir('/home/ec2-user/Fingerprints')):
     if i.endswith(".fpr.txt"):
         fo = open("fp.txt", "a")
         c = i.replace("."," ")


### PR DESCRIPTION
#### 👉 Update script to reflect version currently on the sever

The first commit reflects the version of this script that was present on the sever at the time of investigation. I have subsequently hacked around with it to get it working.

#### 👉 Wrap parsing with a try-else, remove versioning comment

Script was throwing an index out of bounds error and it seems like this may have occurred to the script only partially running the time before.

Adding the try-else wrapper allows us to skip the lines that were the issue, and the troublesome file is overwritten. I have double-checked the updated index.html and it looks correct.  🤔 😅 